### PR TITLE
Feature/abortcontroller

### DIFF
--- a/dist/cjs/index.js
+++ b/dist/cjs/index.js
@@ -171,6 +171,60 @@ var purgeProperties = function(obj) {
  * @typedef {Object.<string, BehaviorDefFn>} BehaviorDef
  */
 
+const abortController = new AbortController();
+const abortControllerSignal = abortController.signal;
+
+function BehaviorCollection(elements) {
+  elements.forEach((el, i) => {
+    this[i] = el;
+  });
+}
+
+BehaviorCollection.prototype = {
+  forEach:function(func){
+    Object.values(this).forEach(value => {
+      func.call(value, value);
+    });
+  },
+  on:function(type,fn,opt){
+    if (typeof opt === 'boolean' && opt === true) {
+      opt = {
+        passive: true
+      };
+    }
+    const options = {
+      signal: abortController.signal,
+      ...opt
+    };
+    this.forEach(el => {
+      el.removeEventListener(type, fn);
+      el.addEventListener(type, fn, options);
+    });
+    return this;
+  },
+  off:function(type){
+    this.forEach(el => {
+      el.removeEventListener(type, fn);
+    });
+    return this;
+  },
+  /*
+  // Add other methods?
+  addClass:function(className){
+    this.forEach(el => {
+      el.classList.add(className);
+    });
+    return this;
+  },
+  removeClass:function(className){
+    this.forEach(el => {
+      el.classList.remove(className);
+    });
+    return this;
+  },
+  */
+};
+
 /**
  * Behavior constructor
  * @constructor
@@ -193,6 +247,8 @@ function Behavior(node, config = {}) {
   this.__isEnabled = false;
   this.__children = config.children;
   this.__breakpoints = config.breakpoints;
+  this.__abortController = abortController;
+  this.__abortControllerSignal = abortControllerSignal;
 
   // Auto-bind all custom methods to "this"
   this.customMethodNames.forEach(methodName => {
@@ -273,12 +329,12 @@ Behavior.prototype = Object.freeze({
 
     if (typeof this.lifecycle?.resized === 'function') {
       this.__resizedBind = this.__resized.bind(this);
-      window.addEventListener('resized', this.__resizedBind);
+      window.addEventListener('resized', this.__resizedBind, { signal: this.__abortController.signal });
     }
 
     if (typeof this.lifecycle.mediaQueryUpdated === 'function' || this.options.media) {
       this.__mediaQueryUpdatedBind = this.__mediaQueryUpdated.bind(this);
-      window.addEventListener('mediaQueryUpdated', this.__mediaQueryUpdatedBind);
+      window.addEventListener('mediaQueryUpdated', this.__mediaQueryUpdatedBind, { signal: this.__abortController.signal });
     }
 
     if (this.options.media) {
@@ -290,6 +346,8 @@ Behavior.prototype = Object.freeze({
     this.__intersections();
   },
   destroy() {
+    this.__abortController.abort();
+
     if (this.__isEnabled === true) {
       this.disable();
     }
@@ -297,14 +355,6 @@ Behavior.prototype = Object.freeze({
     // Behavior-specific lifecycle
     if (typeof this.lifecycle?.destroy === 'function') {
       this.lifecycle.destroy.call(this);
-    }
-
-    if (typeof this.lifecycle.resized === 'function') {
-      window.removeEventListener('resized', this.__resizedBind);
-    }
-
-    if (typeof this.lifecycle.mediaQueryUpdated === 'function' || this.options.media) {
-      window.removeEventListener('mediaQueryUpdated', this.__mediaQueryUpdatedBind);
     }
 
     if (this.lifecycle.intersectionIn != null || this.lifecycle.intersectionOut != null) {
@@ -372,6 +422,15 @@ Behavior.prototype = Object.freeze({
    */
   isBreakpoint(bp) {
     return isBreakpoint(bp, this.__breakpoints);
+  },
+  collection(selector, context) {
+    let nodes = [];
+    if (selector && typeof selector !== 'string') {
+      nodes = (selector.forEach) ? selector : [selector];
+    } else if (selector) {
+      nodes = this.getChildren(selector, context);
+    }
+    return new BehaviorCollection(nodes);
   },
   __toggleEnabled() {
     const isValidMQ = isBreakpoint(this.options.media, this.__breakpoints);

--- a/dist/cjs/index.js
+++ b/dist/cjs/index.js
@@ -274,12 +274,12 @@ Behavior.prototype = Object.freeze({
 
     if (typeof this.lifecycle?.resized === 'function') {
       this.__resizedBind = this.__resized.bind(this);
-      window.addEventListener('resized', this.__resizedBind, { signal: this.__abortController.signal });
+      window.addEventListener('resized', this.__resizedBind);
     }
 
     if (typeof this.lifecycle.mediaQueryUpdated === 'function' || this.options.media) {
       this.__mediaQueryUpdatedBind = this.__mediaQueryUpdated.bind(this);
-      window.addEventListener('mediaQueryUpdated', this.__mediaQueryUpdatedBind, { signal: this.__abortController.signal });
+      window.addEventListener('mediaQueryUpdated', this.__mediaQueryUpdatedBind);
     }
 
     if (this.options.media) {
@@ -301,6 +301,14 @@ Behavior.prototype = Object.freeze({
     if (typeof this.lifecycle?.destroy === 'function') {
       this.lifecycle.destroy.call(this);
     }
+
+    if (typeof this.lifecycle.resized === 'function') {
+       window.removeEventListener('resized', this.__resizedBind);
+     }
+
+     if (typeof this.lifecycle.mediaQueryUpdated === 'function' || this.options.media) {
+       window.removeEventListener('mediaQueryUpdated', this.__mediaQueryUpdatedBind);
+     }
 
     if (this.lifecycle.intersectionIn != null || this.lifecycle.intersectionOut != null) {
       this.__intersectionObserver.unobserve(this.$node);

--- a/dist/cjs/index.js
+++ b/dist/cjs/index.js
@@ -171,60 +171,6 @@ var purgeProperties = function(obj) {
  * @typedef {Object.<string, BehaviorDefFn>} BehaviorDef
  */
 
-const abortController = new AbortController();
-const abortControllerSignal = abortController.signal;
-
-function BehaviorCollection(elements) {
-  elements.forEach((el, i) => {
-    this[i] = el;
-  });
-}
-
-BehaviorCollection.prototype = {
-  forEach:function(func){
-    Object.values(this).forEach(value => {
-      func.call(value, value);
-    });
-  },
-  on:function(type,fn,opt){
-    if (typeof opt === 'boolean' && opt === true) {
-      opt = {
-        passive: true
-      };
-    }
-    const options = {
-      signal: abortController.signal,
-      ...opt
-    };
-    this.forEach(el => {
-      el.removeEventListener(type, fn);
-      el.addEventListener(type, fn, options);
-    });
-    return this;
-  },
-  off:function(type){
-    this.forEach(el => {
-      el.removeEventListener(type, fn);
-    });
-    return this;
-  },
-  /*
-  // Add other methods?
-  addClass:function(className){
-    this.forEach(el => {
-      el.classList.add(className);
-    });
-    return this;
-  },
-  removeClass:function(className){
-    this.forEach(el => {
-      el.classList.remove(className);
-    });
-    return this;
-  },
-  */
-};
-
 /**
  * Behavior constructor
  * @constructor
@@ -247,8 +193,7 @@ function Behavior(node, config = {}) {
   this.__isEnabled = false;
   this.__children = config.children;
   this.__breakpoints = config.breakpoints;
-  this.__abortController = abortController;
-  this.__abortControllerSignal = abortControllerSignal;
+  this.__abortController = new AbortController();
 
   // Auto-bind all custom methods to "this"
   this.customMethodNames.forEach(methodName => {
@@ -371,16 +316,67 @@ Behavior.prototype = Object.freeze({
    * @param {boolean} multi - Define usage between querySelectorAll and querySelector
    * @returns {HTMLElement|null}
    */
-  getChild(childName, context, multi = false) {
-    if (context == null) {
-      context = this.$node;
+  getChild(selector, context, multi = false) {
+      // lets make a selection
+    let selection;
+    //
+    if (this.__children != null && this.__children[selector] != null) {
+      // if the selector matches a pre-selected set, set to that set
+      // TODO: confirm what this is and its usage
+      selection = this.__children[selector];
+    } else if (selector instanceof NodeList) {
+      // if a node list has been passed, use it
+      selection = selector;
+      multi = true;
+    } else if (selector instanceof Element || selector instanceof HTMLDocument || selector === window) {
+      // if a single node, the document or the window is passed, set to that
+      selection = selector;
+      multi = false;
+    } else {
+      // else, lets find named children within the container
+      if (context == null) {
+        // set a default context of the container node
+        context = this.$node;
+      }
+      // find
+      selection = context[multi ? 'querySelectorAll' : 'querySelector'](
+        '[data-' + this.name.toLowerCase() + '-' + selector.toLowerCase() + ']'
+      );
     }
-    if (this.__children != null && this.__children[childName] != null) {
-      return this.__children[childName];
+
+    if (multi) {
+      // apply on/off methods to the selected DOM node list
+      selection.on = (type, fn, opt) => {
+        selection.forEach(el => {
+          this.__on(el, type, fn, opt);
+        });
+      };
+      selection.off = (type, fn) => {
+        selection.forEach(el => {
+          this.__off(el, type, fn);
+        });
+      };
+      // and apply to the individual nodes within
+      selection.forEach(el => {
+        el.on = (type, fn, opt) => {
+          this.__on(el, type, fn, opt);
+        };
+        el.off = (type, fn) => {
+          this.__off(el, type, fn);
+        };
+      });
+    } else {
+      // apply on/off methods to the singular selected node
+      selection.on = (type, fn, opt) => {
+        this.__on(selection, type, fn, opt);
+      };
+      selection.off = (type, fn) => {
+        this.__off(selection, type, fn);
+      };
     }
-    return context[multi ? 'querySelectorAll' : 'querySelector'](
-      '[data-' + this.name.toLowerCase() + '-' + childName.toLowerCase() + ']'
-    );
+
+    // return to variable assignment
+    return selection;
   },
   /**
    * Look for children of the behavior: data-behaviorName-childName
@@ -423,14 +419,53 @@ Behavior.prototype = Object.freeze({
   isBreakpoint(bp) {
     return isBreakpoint(bp, this.__breakpoints);
   },
-  collection(selector, context) {
-    let nodes = [];
-    if (selector && typeof selector !== 'string') {
-      nodes = (selector.forEach) ? selector : [selector];
-    } else if (selector) {
-      nodes = this.getChildren(selector, context);
+  __on(el, type, fn, opt) {
+    if (typeof opt === 'boolean' && opt === true) {
+      opt = {
+        passive: true
+      };
     }
-    return new BehaviorCollection(nodes);
+    const options = {
+      signal: this.__abortController.signal,
+      ...opt
+    };
+    if (!el.attachedListeners) {
+      el.attachedListeners = {};
+    }
+    // check if el already has this listener
+    let found = Object.values(el.attachedListeners).find(listener => listener.type === type && listener.fn === fn);
+    if (!found) {
+      el.attachedListeners[Object.values(el.attachedListeners).length] = {
+        type: type,
+        fn: fn,
+      };
+      el.addEventListener(type, fn, options);
+      /*
+      el.on = (t, f, o) => {
+        this.__on(el, t, f, o);
+      };
+      el.off = (t, f) => {
+        this.__off(el, t, f);
+      };
+      */
+    }
+  },
+  __off(el, type, fn) {
+    if (el.attachedListeners) {
+      Object.keys(el.attachedListeners).forEach(key => {
+        const thisListener = el.attachedListeners[key];
+        if (
+          (!type && !fn) || // off()
+          (type === thisListener.type && !fn) || // match type with no fn
+          (type === thisListener.type && fn === thisListener.fn) // match both type and fn
+        ) {
+          delete el.attachedListeners[key];
+          el.removeEventListener(thisListener.type, thisListener.fn);
+        }
+      });
+    } else {
+      el.removeEventListener(type, fn);
+    }
   },
   __toggleEnabled() {
     const isValidMQ = isBreakpoint(this.options.media, this.__breakpoints);

--- a/dist/cjs/index.js
+++ b/dist/cjs/index.js
@@ -440,14 +440,6 @@ Behavior.prototype = Object.freeze({
         fn: fn,
       };
       el.addEventListener(type, fn, options);
-      /*
-      el.on = (t, f, o) => {
-        this.__on(el, t, f, o);
-      };
-      el.off = (t, f) => {
-        this.__off(el, t, f);
-      };
-      */
     }
   },
   __off(el, type, fn) {

--- a/dist/cjs/index.js
+++ b/dist/cjs/index.js
@@ -358,19 +358,19 @@ Behavior.prototype = Object.freeze({
       };
       // and apply to the individual nodes within
       selection.forEach(el => {
-        el.on = (type, fn, opt) => {
+        el.on = el.on ? el.on : (type, fn, opt) => {
           this.__on(el, type, fn, opt);
         };
-        el.off = (type, fn) => {
+        el.off = el.off ? el.off : (type, fn) => {
           this.__off(el, type, fn);
         };
       });
     } else {
       // apply on/off methods to the singular selected node
-      selection.on = (type, fn, opt) => {
+      selection.on = selection.on ? selection.on : (type, fn, opt) => {
         this.__on(selection, type, fn, opt);
       };
-      selection.off = (type, fn) => {
+      selection.off = selection.off ? selection.off : (type, fn) => {
         this.__off(selection, type, fn);
       };
     }

--- a/dist/esm/index.js
+++ b/dist/esm/index.js
@@ -356,19 +356,19 @@ Behavior.prototype = Object.freeze({
       };
       // and apply to the individual nodes within
       selection.forEach(el => {
-        el.on = (type, fn, opt) => {
+        el.on = el.on ? el.on : (type, fn, opt) => {
           this.__on(el, type, fn, opt);
         };
-        el.off = (type, fn) => {
+        el.off = el.off ? el.off : (type, fn) => {
           this.__off(el, type, fn);
         };
       });
     } else {
       // apply on/off methods to the singular selected node
-      selection.on = (type, fn, opt) => {
+      selection.on = selection.on ? selection.on : (type, fn, opt) => {
         this.__on(selection, type, fn, opt);
       };
-      selection.off = (type, fn) => {
+      selection.off = selection.off ? selection.off : (type, fn) => {
         this.__off(selection, type, fn);
       };
     }

--- a/dist/esm/index.js
+++ b/dist/esm/index.js
@@ -272,12 +272,12 @@ Behavior.prototype = Object.freeze({
 
     if (typeof this.lifecycle?.resized === 'function') {
       this.__resizedBind = this.__resized.bind(this);
-      window.addEventListener('resized', this.__resizedBind, { signal: this.__abortController.signal });
+      window.addEventListener('resized', this.__resizedBind);
     }
 
     if (typeof this.lifecycle.mediaQueryUpdated === 'function' || this.options.media) {
       this.__mediaQueryUpdatedBind = this.__mediaQueryUpdated.bind(this);
-      window.addEventListener('mediaQueryUpdated', this.__mediaQueryUpdatedBind, { signal: this.__abortController.signal });
+      window.addEventListener('mediaQueryUpdated', this.__mediaQueryUpdatedBind);
     }
 
     if (this.options.media) {
@@ -299,6 +299,14 @@ Behavior.prototype = Object.freeze({
     if (typeof this.lifecycle?.destroy === 'function') {
       this.lifecycle.destroy.call(this);
     }
+
+    if (typeof this.lifecycle.resized === 'function') {
+       window.removeEventListener('resized', this.__resizedBind);
+     }
+
+     if (typeof this.lifecycle.mediaQueryUpdated === 'function' || this.options.media) {
+       window.removeEventListener('mediaQueryUpdated', this.__mediaQueryUpdatedBind);
+     }
 
     if (this.lifecycle.intersectionIn != null || this.lifecycle.intersectionOut != null) {
       this.__intersectionObserver.unobserve(this.$node);

--- a/dist/esm/index.js
+++ b/dist/esm/index.js
@@ -438,14 +438,6 @@ Behavior.prototype = Object.freeze({
         fn: fn,
       };
       el.addEventListener(type, fn, options);
-      /*
-      el.on = (t, f, o) => {
-        this.__on(el, t, f, o);
-      };
-      el.off = (t, f) => {
-        this.__off(el, t, f);
-      };
-      */
     }
   },
   __off(el, type, fn) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@area17/a17-behaviors",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@area17/a17-behaviors",
-      "version": "0.2.6",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@area17/a17-helpers": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@area17/a17-behaviors",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "JavaScript framework to attach JavaScript events and interactions to DOM Nodes",
   "type": "module",
   "scripts": {

--- a/src/createBehavior.js
+++ b/src/createBehavior.js
@@ -226,19 +226,19 @@ Behavior.prototype = Object.freeze({
       };
       // and apply to the individual nodes within
       selection.forEach(el => {
-        el.on = (type, fn, opt) => {
+        el.on = el.on ? el.on : (type, fn, opt) => {
           this.__on(el, type, fn, opt);
         };
-        el.off = (type, fn) => {
+        el.off = el.off ? el.off : (type, fn) => {
           this.__off(el, type, fn);
         };
       });
     } else {
       // apply on/off methods to the singular selected node
-      selection.on = (type, fn, opt) => {
+      selection.on = selection.on ? selection.on : (type, fn, opt) => {
         this.__on(selection, type, fn, opt);
       };
-      selection.off = (type, fn) => {
+      selection.off = selection.off ? selection.off : (type, fn) => {
         this.__off(selection, type, fn);
       };
     }

--- a/src/createBehavior.js
+++ b/src/createBehavior.js
@@ -308,14 +308,6 @@ Behavior.prototype = Object.freeze({
         fn: fn,
       };
       el.addEventListener(type, fn, options);
-      /*
-      el.on = (t, f, o) => {
-        this.__on(el, t, f, o);
-      };
-      el.off = (t, f) => {
-        this.__off(el, t, f);
-      };
-      */
     }
   },
   __off(el, type, fn) {

--- a/src/createBehavior.js
+++ b/src/createBehavior.js
@@ -39,73 +39,6 @@ import manageBehaviors from './manageBehaviors';
  * @typedef {Object.<string, BehaviorDefFn>} BehaviorDef
  */
 
-const abortController = new AbortController();
-const abortControllerSignal = abortController.signal;
-
-function BehaviorCollection(elements) {
-  elements.forEach((el, i) => {
-    this[i] = el;
-  });
-}
-
-BehaviorCollection.prototype = {
-  on:function(type,fn,opt){
-    if (typeof opt === 'boolean' && opt === true) {
-      opt = {
-        passive: true
-      };
-    }
-    const options = {
-      signal: abortController.signal,
-      ...opt
-    };
-    Object.values(this).forEach(el => {
-      if (!el.attachedListeners) {
-        el.attachedListeners = {};
-      }
-      // check if el already has this listener
-      let found = Object.values(el.attachedListeners).find(listener => listener.type === type && listener.fn === fn);
-      if (!found) {
-        el.attachedListeners[Object.values(el.attachedListeners).length] = {
-          type: type,
-          fn: fn,
-        };
-        el.addEventListener(type, fn, options);
-      }
-    });
-    return this;
-  },
-  off:function(type, fn){
-    Object.values(this).forEach(el => {
-      if (el.attachedListeners) {
-        Object.keys(el.attachedListeners).forEach(key => {
-          const thisListener = el.attachedListeners[key];
-          if (
-            (!type && !fn) || // off()
-            (type === thisListener.type && !fn) || // match type with no fn
-            (type === thisListener.type && fn === thisListener.fn) // match both type and fn
-          ) {
-            delete el.attachedListeners[key];
-            el.removeEventListener(thisListener.type, thisListener.fn);
-          }
-        });
-      } else {
-        el.removeEventListener(type, fn);
-      }
-    });
-    return this;
-  },
-  indexOf:function(needle){
-    // possibly remove, easy enough to add your own?
-    let index = -1;
-    Object.values(this).some((el, i) => {
-      index = (el === needle) ? i : index;
-      return index > -1;
-    });
-    return index;
-  }
-};
-
 /**
  * Behavior constructor
  * @constructor
@@ -128,8 +61,7 @@ function Behavior(node, config = {}) {
   this.__isEnabled = false;
   this.__children = config.children;
   this.__breakpoints = config.breakpoints;
-  this.__abortController = abortController;
-  this.__abortControllerSignal = abortControllerSignal;
+  this.__abortController = new AbortController();
 
   // Auto-bind all custom methods to "this"
   this.customMethodNames.forEach(methodName => {
@@ -252,16 +184,67 @@ Behavior.prototype = Object.freeze({
    * @param {boolean} multi - Define usage between querySelectorAll and querySelector
    * @returns {HTMLElement|null}
    */
-  getChild(childName, context, multi = false) {
-    if (context == null) {
-      context = this.$node;
+  getChild(selector, context, multi = false) {
+      // lets make a selection
+    let selection;
+    //
+    if (this.__children != null && this.__children[selector] != null) {
+      // if the selector matches a pre-selected set, set to that set
+      // TODO: confirm what this is and its usage
+      selection = this.__children[selector];
+    } else if (selector instanceof NodeList) {
+      // if a node list has been passed, use it
+      selection = selector;
+      multi = true;
+    } else if (selector instanceof Element || selector instanceof HTMLDocument || selector === window) {
+      // if a single node, the document or the window is passed, set to that
+      selection = selector;
+      multi = false;
+    } else {
+      // else, lets find named children within the container
+      if (context == null) {
+        // set a default context of the container node
+        context = this.$node;
+      }
+      // find
+      selection = context[multi ? 'querySelectorAll' : 'querySelector'](
+        '[data-' + this.name.toLowerCase() + '-' + selector.toLowerCase() + ']'
+      );
     }
-    if (this.__children != null && this.__children[childName] != null) {
-      return this.__children[childName];
+
+    if (multi) {
+      // apply on/off methods to the selected DOM node list
+      selection.on = (type, fn, opt) => {
+        selection.forEach(el => {
+          this.__on(el, type, fn, opt);
+        });
+      };
+      selection.off = (type, fn) => {
+        selection.forEach(el => {
+          this.__off(el, type, fn);
+        });
+      };
+      // and apply to the individual nodes within
+      selection.forEach(el => {
+        el.on = (type, fn, opt) => {
+          this.__on(el, type, fn, opt);
+        };
+        el.off = (type, fn) => {
+          this.__off(el, type, fn);
+        };
+      });
+    } else {
+      // apply on/off methods to the singular selected node
+      selection.on = (type, fn, opt) => {
+        this.__on(selection, type, fn, opt);
+      };
+      selection.off = (type, fn) => {
+        this.__off(selection, type, fn);
+      };
     }
-    return context[multi ? 'querySelectorAll' : 'querySelector'](
-      '[data-' + this.name.toLowerCase() + '-' + childName.toLowerCase() + ']'
-    );
+
+    // return to variable assignment
+    return selection;
   },
   /**
    * Look for children of the behavior: data-behaviorName-childName
@@ -304,14 +287,53 @@ Behavior.prototype = Object.freeze({
   isBreakpoint(bp) {
     return isBreakpoint(bp, this.__breakpoints);
   },
-  collection(selector, context) {
-    let nodes = [];
-    if (selector && typeof selector !== 'string') {
-      nodes = (selector.forEach) ? selector : [selector];
-    } else if (selector) {
-      nodes = this.getChildren(selector, context);
+  __on(el, type, fn, opt) {
+    if (typeof opt === 'boolean' && opt === true) {
+      opt = {
+        passive: true
+      };
     }
-    return new BehaviorCollection(nodes);
+    const options = {
+      signal: this.__abortController.signal,
+      ...opt
+    };
+    if (!el.attachedListeners) {
+      el.attachedListeners = {};
+    }
+    // check if el already has this listener
+    let found = Object.values(el.attachedListeners).find(listener => listener.type === type && listener.fn === fn);
+    if (!found) {
+      el.attachedListeners[Object.values(el.attachedListeners).length] = {
+        type: type,
+        fn: fn,
+      };
+      el.addEventListener(type, fn, options);
+      /*
+      el.on = (t, f, o) => {
+        this.__on(el, t, f, o);
+      };
+      el.off = (t, f) => {
+        this.__off(el, t, f);
+      };
+      */
+    }
+  },
+  __off(el, type, fn) {
+    if (el.attachedListeners) {
+      Object.keys(el.attachedListeners).forEach(key => {
+        const thisListener = el.attachedListeners[key];
+        if (
+          (!type && !fn) || // off()
+          (type === thisListener.type && !fn) || // match type with no fn
+          (type === thisListener.type && fn === thisListener.fn) // match both type and fn
+        ) {
+          delete el.attachedListeners[key];
+          el.removeEventListener(thisListener.type, thisListener.fn);
+        }
+      });
+    } else {
+      el.removeEventListener(type, fn);
+    }
   },
   __toggleEnabled() {
     const isValidMQ = isBreakpoint(this.options.media, this.__breakpoints);

--- a/src/createBehavior.js
+++ b/src/createBehavior.js
@@ -142,12 +142,12 @@ Behavior.prototype = Object.freeze({
 
     if (typeof this.lifecycle?.resized === 'function') {
       this.__resizedBind = this.__resized.bind(this);
-      window.addEventListener('resized', this.__resizedBind, { signal: this.__abortController.signal });
+      window.addEventListener('resized', this.__resizedBind);
     }
 
     if (typeof this.lifecycle.mediaQueryUpdated === 'function' || this.options.media) {
       this.__mediaQueryUpdatedBind = this.__mediaQueryUpdated.bind(this);
-      window.addEventListener('mediaQueryUpdated', this.__mediaQueryUpdatedBind, { signal: this.__abortController.signal });
+      window.addEventListener('mediaQueryUpdated', this.__mediaQueryUpdatedBind);
     }
 
     if (this.options.media) {
@@ -169,6 +169,14 @@ Behavior.prototype = Object.freeze({
     if (typeof this.lifecycle?.destroy === 'function') {
       this.lifecycle.destroy.call(this);
     }
+
+    if (typeof this.lifecycle.resized === 'function') {
+       window.removeEventListener('resized', this.__resizedBind);
+     }
+
+     if (typeof this.lifecycle.mediaQueryUpdated === 'function' || this.options.media) {
+       window.removeEventListener('mediaQueryUpdated', this.__mediaQueryUpdatedBind);
+     }
 
     if (this.lifecycle.intersectionIn != null || this.lifecycle.intersectionOut != null) {
       this.__intersectionObserver.unobserve(this.$node);


### PR DESCRIPTION
Use the `AbortController()`'s ability to remove multiple event listeners on `abort()` to auto remove event listeners on behavior `destroy()`.

See [this article](https://www.macarthur.me/posts/options-for-removing-event-listeners).

A common thing we see with behaviors is lots of `this.$foo.removeEventListener('bar', this.baz);` in a behavior `destroy()` method. Which is the intended use case, but, its easy to forget one and they're a pain to maintain - its a chore.

Being able to automatically remove event listeners on behavior `destroy()` would be nice.
Another benefit of using an abort signal is that you could automatically remove anonymous functions, should you need to use those.

The easiest way would be to for each behavior to have a `this.abortController` and then every `addEventListener` would need `{ signal: this.abortController.signal }` as its 3rd param, eg:

```JavaScript
this.$btn.addEventListener('click', this.handleClick, { signal: this.abortController.signal });
```

But, as @kylegoines points out - developers probably won't notice they can use it.

---

The nicest thing we could have would be:

```JavaScript
this.$btn.addEventListener('click', this.handleClick);
```

And behaviours somehow automagically appends `{ signal: this.abortController.signal }` to the listener (also take into account that you may want `{ passive: true }` or some other options. I don't know of a way to do this kind of fiddling with the methods/prototype of a DOM node *only* if its a named thing inside a behavior - @m4n1ok, @joecritch any idea?

---

This branch updates the existing `getChild` and `getChildren` methods (backwards compatible), adding `on` and `off` methods to the selection and children of the selection.

```JavaScript
this.$btns = this.getChildren('btn'); // makes a collection using behavior's `this.getChildren('btn')`
// or
this.$btn = this.getChild('btn'); // makes a collection using behavior's `this.getChildren('btn')`
// or
this.$btns = this.getChildren(document.querySelector('button')) // makes a collection based on a single DOM node
// or
this.$btns = this.getChild(document.querySelectorAll('button')) // makes a collection based on a single DOM nodelist
// or
this.$btns = this.getChild(window) // makes a collection based on `window`
```

Where:

```JavaScript
console.log(this.$btns); // NodeList(2) [button, button, on: ƒ, off: ƒ]
console.log(typeof this.$btns); // object
console.log(this.$btns[0]); // a DOM node (as as any nodelist)
```

And then you can add event listeners to a collection:

```JavaScript
// and then
this.$btns.on('click', this.handleClick); // adds a click listener to all items in the collection with function `this.handleClick`
// or 
this.$btns.on('click', () => {
    console.log('hello world');  // adds a click listener to all items in the collection with anonymous function
});
// can also pass options
this.$btns.on('click', this.handleClick, { passive: true }); // adds a click listener to all items in the collection with function `this.handleClick` and `passive: true` option
// or select single items and add
this.$btns[0].on('click', this.handleClick); // adds a click listener to the first item in the collection with function `this.handleClick`
```

These will be be automatically cleaned up on behavior `destroy()`.
(if you pass a custom abort controller signal as an option, it won't auto destroy)

You could also:

```JavaScript
// also
window.addEventListener('resize', () => {
    console.log('resize');
}, {
    signal: this.__abortController.signal
});
```

And this would also be cleaned up on behavior `destroy()`.

Should you also want to manually remove listeners you can:

```JavaScript
this.$btns.off('click', this.handleClick); // removes all `click` listeners with the function `this.handleClick`
this.$btns.off('click'); // removes all `click` listeners, regardless of their associated functions
this.$btns.off(); // removes all event listeners, regardless of their type and associated function
this.$btns[0].off('click', this.handleClick); // removes the listener from just the first element
```

If you select an element that was previously in a selection, it will have `on` and `off` methods:

```JavaScript
this.$btns = this.getChildren('btn');
console.log(typeof this.$node.querySelector('button').on); // function
```

Which means you can do:

```JavaScript
this.$btns.on('click', (event) => {
    event.currentTarget.off('click); // will remove all 'click' listeners from the clicked button
});
```

Listeners won't be added twice:

```JavaScript
this.$btns.on('click', this.handleClick);
this.$btns.on('click', this.handleClick); // won't add the handler twice
```

---

Using `on` and `off` as not to confuse with `addEventListener` and `removeEventListener`. On individual nodes, native `addEventListener` and `removeEventListener` are still available.

---

To do:

- [x] cross browser check
- [x] consider [polyfill](https://www.npmjs.com/package/abort-controller) requirement 
- [x] check to see if a `getChild` found element that then becomes a plugin container, eg. a Splide container, that the plugin `on` and `off` methods correctly overwrite the behavior collection methods
