### PR TITLE
Feature/extendBehavior

### DIFF
--- a/build.js
+++ b/build.js
@@ -3,8 +3,10 @@ const fs = require('fs');
 try {
   const manageBehaviors = fs.readFileSync('src/manageBehaviors.js', 'utf8');
   const createBehavior = fs.readFileSync('src/createBehavior.js', 'utf8');
+  const extendBehavior = fs.readFileSync('src/extendBehavior.js', 'utf8');
   fs.writeFileSync('dist/manageBehaviors.js', '// don\'t edit this file' + '\n\n' + manageBehaviors);
   fs.writeFileSync('dist/createBehavior.js', '// don\'t edit this file' + '\n\n' + createBehavior);
+  fs.writeFileSync('dist/extendBehavior.js', '// don\'t edit this file' + '\n\n' + extendBehavior);
   console.log('✅');
 } catch (err) {
   console.error(err);

--- a/dist/cjs/index.js
+++ b/dist/cjs/index.js
@@ -1200,17 +1200,8 @@ var manageBehaviors = exportObj;
  * NB: methods or lifestyle fns with the same name will overwrite originals
  */
 function extendBehavior(behavior, name, methods = {}, lifecycle = {}) {
-  const newMethods = behavior.prototype.methods;
-  const methodsKeys = Object.keys(methods);
-  methodsKeys.forEach(key => {
-    newMethods[key] = methods[key];
-  });
-
-  const newLifecycle = behavior.prototype.lifecycle;
-  const lifecycleKeys = Object.keys(lifecycle);
-  lifecycleKeys.forEach(key => {
-    newLifecycle[key] = lifecycle[key];
-  });
+  const newMethods = Object.assign(Object.assign({}, behavior.prototype.methods), methods);
+  const newLifecycle = Object.assign(Object.assign({}, behavior.prototype.lifecycle), lifecycle);
 
   return createBehavior(name, newMethods, newLifecycle);
 }

--- a/dist/cjs/index.js
+++ b/dist/cjs/index.js
@@ -196,7 +196,7 @@ function Behavior(node, config = {}) {
 
   // Auto-bind all custom methods to "this"
   this.customMethodNames.forEach(methodName => {
-    this[methodName] = this[methodName].bind(this);
+    this[methodName] = this.methods[methodName].bind(this);
   });
 
   this._binds = {};
@@ -421,11 +421,11 @@ Behavior.prototype = Object.freeze({
 /**
  * Create a behavior instance
  * @param {string} name - Name of the behavior used for declaration: data-behavior="name"
- * @param {BehaviorDef} def - define methods of the behavior
- * @param {Lifecycle} lifecycle - Register behavior lifecycle
+ * @param {object} methods - define methods of the behavior
+ * @param {object} lifecycle - Register behavior lifecycle
  * @returns {Behavior}
  */
-const createBehavior = (name, def, lifecycle = {}) => {
+const createBehavior = (name, methods = {}, lifecycle = {}) => {
   /**
    *
    * @param args
@@ -449,22 +449,22 @@ const createBehavior = (name, def, lifecycle = {}) => {
     lifecycle: {
       value: lifecycle,
     },
+    methods: {
+      value: methods,
+    },
     customMethodNames: {
       value: customMethodNames,
     },
   };
 
   // Expose the definition properties as 'this[methodName]'
-  const defKeys = Object.keys(def);
-  defKeys.forEach(key => {
+  const methodsKeys = Object.keys(methods);
+  methodsKeys.forEach(key => {
     customMethodNames.push(key);
-    customProperties[key] = {
-      value: def[key],
-      writable: true,
-    };
   });
 
   fn.prototype = Object.create(Behavior.prototype, customProperties);
+
   return fn;
 };
 
@@ -1095,5 +1095,32 @@ try {
 
 var manageBehaviors = exportObj;
 
+/**
+ * Extend an existing a behavior instance
+ * @param {module} behavior - behavior you want to extend
+ * @param {string} name - Name of the extended behavior used for declaration: data-behavior="name"
+ * @param {object} methods - define methods of the behavior
+ * @param {object} lifecycle - Register behavior lifecycle
+ * @returns {Behavior}
+ *
+ * NB: methods or lifestyle fns with the same name will overwrite originals
+ */
+function extendBehavior(behavior, name, methods = {}, lifecycle = {}) {
+  const newMethods = behavior.prototype.methods;
+  const methodsKeys = Object.keys(methods);
+  methodsKeys.forEach(key => {
+    newMethods[key] = methods[key];
+  });
+
+  const newLifecycle = behavior.prototype.lifecycle;
+  const lifecycleKeys = Object.keys(lifecycle);
+  lifecycleKeys.forEach(key => {
+    newLifecycle[key] = lifecycle[key];
+  });
+
+  return createBehavior(name, newMethods, newLifecycle);
+}
+
 exports.createBehavior = createBehavior;
+exports.extendBehavior = extendBehavior;
 exports.manageBehaviors = manageBehaviors;

--- a/dist/esm/index.js
+++ b/dist/esm/index.js
@@ -1198,17 +1198,8 @@ var manageBehaviors = exportObj;
  * NB: methods or lifestyle fns with the same name will overwrite originals
  */
 function extendBehavior(behavior, name, methods = {}, lifecycle = {}) {
-  const newMethods = behavior.prototype.methods;
-  const methodsKeys = Object.keys(methods);
-  methodsKeys.forEach(key => {
-    newMethods[key] = methods[key];
-  });
-
-  const newLifecycle = behavior.prototype.lifecycle;
-  const lifecycleKeys = Object.keys(lifecycle);
-  lifecycleKeys.forEach(key => {
-    newLifecycle[key] = lifecycle[key];
-  });
+  const newMethods = Object.assign(Object.assign({}, behavior.prototype.methods), methods);
+  const newLifecycle = Object.assign(Object.assign({}, behavior.prototype.lifecycle), lifecycle);
 
   return createBehavior(name, newMethods, newLifecycle);
 }

--- a/dist/esm/index.js
+++ b/dist/esm/index.js
@@ -194,7 +194,7 @@ function Behavior(node, config = {}) {
 
   // Auto-bind all custom methods to "this"
   this.customMethodNames.forEach(methodName => {
-    this[methodName] = this[methodName].bind(this);
+    this[methodName] = this.methods[methodName].bind(this);
   });
 
   this._binds = {};
@@ -419,11 +419,11 @@ Behavior.prototype = Object.freeze({
 /**
  * Create a behavior instance
  * @param {string} name - Name of the behavior used for declaration: data-behavior="name"
- * @param {BehaviorDef} def - define methods of the behavior
- * @param {Lifecycle} lifecycle - Register behavior lifecycle
+ * @param {object} methods - define methods of the behavior
+ * @param {object} lifecycle - Register behavior lifecycle
  * @returns {Behavior}
  */
-const createBehavior = (name, def, lifecycle = {}) => {
+const createBehavior = (name, methods = {}, lifecycle = {}) => {
   /**
    *
    * @param args
@@ -447,22 +447,22 @@ const createBehavior = (name, def, lifecycle = {}) => {
     lifecycle: {
       value: lifecycle,
     },
+    methods: {
+      value: methods,
+    },
     customMethodNames: {
       value: customMethodNames,
     },
   };
 
   // Expose the definition properties as 'this[methodName]'
-  const defKeys = Object.keys(def);
-  defKeys.forEach(key => {
+  const methodsKeys = Object.keys(methods);
+  methodsKeys.forEach(key => {
     customMethodNames.push(key);
-    customProperties[key] = {
-      value: def[key],
-      writable: true,
-    };
   });
 
   fn.prototype = Object.create(Behavior.prototype, customProperties);
+
   return fn;
 };
 
@@ -1093,4 +1093,30 @@ try {
 
 var manageBehaviors = exportObj;
 
-export { createBehavior, manageBehaviors };
+/**
+ * Extend an existing a behavior instance
+ * @param {module} behavior - behavior you want to extend
+ * @param {string} name - Name of the extended behavior used for declaration: data-behavior="name"
+ * @param {object} methods - define methods of the behavior
+ * @param {object} lifecycle - Register behavior lifecycle
+ * @returns {Behavior}
+ *
+ * NB: methods or lifestyle fns with the same name will overwrite originals
+ */
+function extendBehavior(behavior, name, methods = {}, lifecycle = {}) {
+  const newMethods = behavior.prototype.methods;
+  const methodsKeys = Object.keys(methods);
+  methodsKeys.forEach(key => {
+    newMethods[key] = methods[key];
+  });
+
+  const newLifecycle = behavior.prototype.lifecycle;
+  const lifecycleKeys = Object.keys(lifecycle);
+  lifecycleKeys.forEach(key => {
+    newLifecycle[key] = lifecycle[key];
+  });
+
+  return createBehavior(name, newMethods, newLifecycle);
+}
+
+export { createBehavior, extendBehavior, manageBehaviors };

--- a/dist/esm/index.js
+++ b/dist/esm/index.js
@@ -191,6 +191,7 @@ function Behavior(node, config = {}) {
   this.__isEnabled = false;
   this.__children = config.children;
   this.__breakpoints = config.breakpoints;
+  this.__abortController = new AbortController();
 
   // Auto-bind all custom methods to "this"
   this.customMethodNames.forEach(methodName => {
@@ -288,6 +289,8 @@ Behavior.prototype = Object.freeze({
     this.__intersections();
   },
   destroy() {
+    this.__abortController.abort();
+
     if (this.__isEnabled === true) {
       this.disable();
     }
@@ -298,12 +301,12 @@ Behavior.prototype = Object.freeze({
     }
 
     if (typeof this.lifecycle.resized === 'function') {
-      window.removeEventListener('resized', this.__resizedBind);
-    }
+       window.removeEventListener('resized', this.__resizedBind);
+     }
 
-    if (typeof this.lifecycle.mediaQueryUpdated === 'function' || this.options.media) {
-      window.removeEventListener('mediaQueryUpdated', this.__mediaQueryUpdatedBind);
-    }
+     if (typeof this.lifecycle.mediaQueryUpdated === 'function' || this.options.media) {
+       window.removeEventListener('mediaQueryUpdated', this.__mediaQueryUpdatedBind);
+     }
 
     if (this.lifecycle.intersectionIn != null || this.lifecycle.intersectionOut != null) {
       this.__intersectionObserver.unobserve(this.$node);
@@ -319,16 +322,67 @@ Behavior.prototype = Object.freeze({
    * @param {boolean} multi - Define usage between querySelectorAll and querySelector
    * @returns {HTMLElement|null}
    */
-  getChild(childName, context, multi = false) {
-    if (context == null) {
-      context = this.$node;
+  getChild(selector, context, multi = false) {
+      // lets make a selection
+    let selection;
+    //
+    if (this.__children != null && this.__children[selector] != null) {
+      // if the selector matches a pre-selected set, set to that set
+      // TODO: confirm what this is and its usage
+      selection = this.__children[selector];
+    } else if (selector instanceof NodeList) {
+      // if a node list has been passed, use it
+      selection = selector;
+      multi = true;
+    } else if (selector instanceof Element || selector instanceof HTMLDocument || selector === window) {
+      // if a single node, the document or the window is passed, set to that
+      selection = selector;
+      multi = false;
+    } else {
+      // else, lets find named children within the container
+      if (context == null) {
+        // set a default context of the container node
+        context = this.$node;
+      }
+      // find
+      selection = context[multi ? 'querySelectorAll' : 'querySelector'](
+        '[data-' + this.name.toLowerCase() + '-' + selector.toLowerCase() + ']'
+      );
     }
-    if (this.__children != null && this.__children[childName] != null) {
-      return this.__children[childName];
+
+    if (multi) {
+      // apply on/off methods to the selected DOM node list
+      selection.on = (type, fn, opt) => {
+        selection.forEach(el => {
+          this.__on(el, type, fn, opt);
+        });
+      };
+      selection.off = (type, fn) => {
+        selection.forEach(el => {
+          this.__off(el, type, fn);
+        });
+      };
+      // and apply to the individual nodes within
+      selection.forEach(el => {
+        el.on = el.on ? el.on : (type, fn, opt) => {
+          this.__on(el, type, fn, opt);
+        };
+        el.off = el.off ? el.off : (type, fn) => {
+          this.__off(el, type, fn);
+        };
+      });
+    } else {
+      // apply on/off methods to the singular selected node
+      selection.on = selection.on ? selection.on : (type, fn, opt) => {
+        this.__on(selection, type, fn, opt);
+      };
+      selection.off = selection.off ? selection.off : (type, fn) => {
+        this.__off(selection, type, fn);
+      };
     }
-    return context[multi ? 'querySelectorAll' : 'querySelector'](
-      '[data-' + this.name.toLowerCase() + '-' + childName.toLowerCase() + ']'
-    );
+
+    // return to variable assignment
+    return selection;
   },
   /**
    * Look for children of the behavior: data-behaviorName-childName
@@ -370,6 +424,46 @@ Behavior.prototype = Object.freeze({
    */
   isBreakpoint(bp) {
     return isBreakpoint(bp, this.__breakpoints);
+  },
+  __on(el, type, fn, opt) {
+    if (typeof opt === 'boolean' && opt === true) {
+      opt = {
+        passive: true
+      };
+    }
+    const options = {
+      signal: this.__abortController.signal,
+      ...opt
+    };
+    if (!el.attachedListeners) {
+      el.attachedListeners = {};
+    }
+    // check if el already has this listener
+    let found = Object.values(el.attachedListeners).find(listener => listener.type === type && listener.fn === fn);
+    if (!found) {
+      el.attachedListeners[Object.values(el.attachedListeners).length] = {
+        type: type,
+        fn: fn,
+      };
+      el.addEventListener(type, fn, options);
+    }
+  },
+  __off(el, type, fn) {
+    if (el.attachedListeners) {
+      Object.keys(el.attachedListeners).forEach(key => {
+        const thisListener = el.attachedListeners[key];
+        if (
+          (!type && !fn) || // off()
+          (type === thisListener.type && !fn) || // match type with no fn
+          (type === thisListener.type && fn === thisListener.fn) // match both type and fn
+        ) {
+          delete el.attachedListeners[key];
+          el.removeEventListener(thisListener.type, thisListener.fn);
+        }
+      });
+    } else {
+      el.removeEventListener(type, fn);
+    }
   },
   __toggleEnabled() {
     const isValidMQ = isBreakpoint(this.options.media, this.__breakpoints);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@area17/a17-behaviors",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@area17/a17-behaviors",
-      "version": "0.2.6",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@area17/a17-helpers": "^3.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@area17/a17-behaviors",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@area17/a17-behaviors",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@area17/a17-helpers": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@area17/a17-behaviors",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "JavaScript framework to attach JavaScript events and interactions to DOM Nodes",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@area17/a17-behaviors",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "JavaScript framework to attach JavaScript events and interactions to DOM Nodes",
   "type": "module",
   "scripts": {

--- a/src/createBehavior.js
+++ b/src/createBehavior.js
@@ -64,7 +64,7 @@ function Behavior(node, config = {}) {
 
   // Auto-bind all custom methods to "this"
   this.customMethodNames.forEach(methodName => {
-    this[methodName] = this[methodName].bind(this);
+    this[methodName] = this.methods[methodName].bind(this);
   });
 
   this._binds = {};
@@ -289,11 +289,11 @@ Behavior.prototype = Object.freeze({
 /**
  * Create a behavior instance
  * @param {string} name - Name of the behavior used for declaration: data-behavior="name"
- * @param {BehaviorDef} def - define methods of the behavior
- * @param {Lifecycle} lifecycle - Register behavior lifecycle
+ * @param {object} methods - define methods of the behavior
+ * @param {object} lifecycle - Register behavior lifecycle
  * @returns {Behavior}
  */
-const createBehavior = (name, def, lifecycle = {}) => {
+const createBehavior = (name, methods = {}, lifecycle = {}) => {
   /**
    *
    * @param args
@@ -317,22 +317,22 @@ const createBehavior = (name, def, lifecycle = {}) => {
     lifecycle: {
       value: lifecycle,
     },
+    methods: {
+      value: methods,
+    },
     customMethodNames: {
       value: customMethodNames,
     },
   };
 
   // Expose the definition properties as 'this[methodName]'
-  const defKeys = Object.keys(def);
-  defKeys.forEach(key => {
+  const methodsKeys = Object.keys(methods);
+  methodsKeys.forEach(key => {
     customMethodNames.push(key);
-    customProperties[key] = {
-      value: def[key],
-      writable: true,
-    };
   });
 
   fn.prototype = Object.create(Behavior.prototype, customProperties);
+
   return fn;
 };
 

--- a/src/createBehavior.js
+++ b/src/createBehavior.js
@@ -61,6 +61,7 @@ function Behavior(node, config = {}) {
   this.__isEnabled = false;
   this.__children = config.children;
   this.__breakpoints = config.breakpoints;
+  this.__abortController = new AbortController();
 
   // Auto-bind all custom methods to "this"
   this.customMethodNames.forEach(methodName => {
@@ -158,6 +159,8 @@ Behavior.prototype = Object.freeze({
     this.__intersections();
   },
   destroy() {
+    this.__abortController.abort();
+
     if (this.__isEnabled === true) {
       this.disable();
     }
@@ -168,12 +171,12 @@ Behavior.prototype = Object.freeze({
     }
 
     if (typeof this.lifecycle.resized === 'function') {
-      window.removeEventListener('resized', this.__resizedBind);
-    }
+       window.removeEventListener('resized', this.__resizedBind);
+     }
 
-    if (typeof this.lifecycle.mediaQueryUpdated === 'function' || this.options.media) {
-      window.removeEventListener('mediaQueryUpdated', this.__mediaQueryUpdatedBind);
-    }
+     if (typeof this.lifecycle.mediaQueryUpdated === 'function' || this.options.media) {
+       window.removeEventListener('mediaQueryUpdated', this.__mediaQueryUpdatedBind);
+     }
 
     if (this.lifecycle.intersectionIn != null || this.lifecycle.intersectionOut != null) {
       this.__intersectionObserver.unobserve(this.$node);
@@ -189,16 +192,67 @@ Behavior.prototype = Object.freeze({
    * @param {boolean} multi - Define usage between querySelectorAll and querySelector
    * @returns {HTMLElement|null}
    */
-  getChild(childName, context, multi = false) {
-    if (context == null) {
-      context = this.$node;
+  getChild(selector, context, multi = false) {
+      // lets make a selection
+    let selection;
+    //
+    if (this.__children != null && this.__children[selector] != null) {
+      // if the selector matches a pre-selected set, set to that set
+      // TODO: confirm what this is and its usage
+      selection = this.__children[selector];
+    } else if (selector instanceof NodeList) {
+      // if a node list has been passed, use it
+      selection = selector;
+      multi = true;
+    } else if (selector instanceof Element || selector instanceof HTMLDocument || selector === window) {
+      // if a single node, the document or the window is passed, set to that
+      selection = selector;
+      multi = false;
+    } else {
+      // else, lets find named children within the container
+      if (context == null) {
+        // set a default context of the container node
+        context = this.$node;
+      }
+      // find
+      selection = context[multi ? 'querySelectorAll' : 'querySelector'](
+        '[data-' + this.name.toLowerCase() + '-' + selector.toLowerCase() + ']'
+      );
     }
-    if (this.__children != null && this.__children[childName] != null) {
-      return this.__children[childName];
+
+    if (multi) {
+      // apply on/off methods to the selected DOM node list
+      selection.on = (type, fn, opt) => {
+        selection.forEach(el => {
+          this.__on(el, type, fn, opt);
+        });
+      };
+      selection.off = (type, fn) => {
+        selection.forEach(el => {
+          this.__off(el, type, fn);
+        });
+      };
+      // and apply to the individual nodes within
+      selection.forEach(el => {
+        el.on = el.on ? el.on : (type, fn, opt) => {
+          this.__on(el, type, fn, opt);
+        };
+        el.off = el.off ? el.off : (type, fn) => {
+          this.__off(el, type, fn);
+        };
+      });
+    } else {
+      // apply on/off methods to the singular selected node
+      selection.on = selection.on ? selection.on : (type, fn, opt) => {
+        this.__on(selection, type, fn, opt);
+      };
+      selection.off = selection.off ? selection.off : (type, fn) => {
+        this.__off(selection, type, fn);
+      };
     }
-    return context[multi ? 'querySelectorAll' : 'querySelector'](
-      '[data-' + this.name.toLowerCase() + '-' + childName.toLowerCase() + ']'
-    );
+
+    // return to variable assignment
+    return selection;
   },
   /**
    * Look for children of the behavior: data-behaviorName-childName
@@ -240,6 +294,46 @@ Behavior.prototype = Object.freeze({
    */
   isBreakpoint(bp) {
     return isBreakpoint(bp, this.__breakpoints);
+  },
+  __on(el, type, fn, opt) {
+    if (typeof opt === 'boolean' && opt === true) {
+      opt = {
+        passive: true
+      };
+    }
+    const options = {
+      signal: this.__abortController.signal,
+      ...opt
+    };
+    if (!el.attachedListeners) {
+      el.attachedListeners = {};
+    }
+    // check if el already has this listener
+    let found = Object.values(el.attachedListeners).find(listener => listener.type === type && listener.fn === fn);
+    if (!found) {
+      el.attachedListeners[Object.values(el.attachedListeners).length] = {
+        type: type,
+        fn: fn,
+      };
+      el.addEventListener(type, fn, options);
+    }
+  },
+  __off(el, type, fn) {
+    if (el.attachedListeners) {
+      Object.keys(el.attachedListeners).forEach(key => {
+        const thisListener = el.attachedListeners[key];
+        if (
+          (!type && !fn) || // off()
+          (type === thisListener.type && !fn) || // match type with no fn
+          (type === thisListener.type && fn === thisListener.fn) // match both type and fn
+        ) {
+          delete el.attachedListeners[key];
+          el.removeEventListener(thisListener.type, thisListener.fn);
+        }
+      });
+    } else {
+      el.removeEventListener(type, fn);
+    }
   },
   __toggleEnabled() {
     const isValidMQ = isBreakpoint(this.options.media, this.__breakpoints);

--- a/src/extendBehavior.js
+++ b/src/extendBehavior.js
@@ -11,27 +11,8 @@ import createBehavior from './createBehavior';
  * NB: methods or lifestyle fns with the same name will overwrite originals
  */
 function extendBehavior(behavior, name, methods = {}, lifecycle = {}) {
-  const newMethods = {};
-  let methodsKeys = Object.keys(behavior.prototype.methods);
-  methodsKeys.forEach(key => {
-    newMethods[key] = behavior.prototype.methods[key];
-  });
-
-  methodsKeys = Object.keys(methods);
-  methodsKeys.forEach(key => {
-    newMethods[key] = methods[key];
-  });
-
-  const newLifecycle = {};
-  let lifecycleKeys = Object.keys(behavior.prototype.lifecycle);
-  lifecycleKeys.forEach(key => {
-    newLifecycle[key] = behavior.prototype.lifecycle[key];
-  });
-
-  lifecycleKeys = Object.keys(lifecycle);
-  lifecycleKeys.forEach(key => {
-    newLifecycle[key] = lifecycle[key];
-  });
+  const newMethods = Object.assign(Object.assign({}, behavior.prototype.methods), methods);
+  const newLifecycle = Object.assign(Object.assign({}, behavior.prototype.lifecycle), lifecycle);
 
   return createBehavior(name, newMethods, newLifecycle);
 }

--- a/src/extendBehavior.js
+++ b/src/extendBehavior.js
@@ -11,14 +11,24 @@ import createBehavior from './createBehavior';
  * NB: methods or lifestyle fns with the same name will overwrite originals
  */
 function extendBehavior(behavior, name, methods = {}, lifecycle = {}) {
-  const newMethods = behavior.prototype.methods;
-  const methodsKeys = Object.keys(methods);
+  const newMethods = {};
+  let methodsKeys = Object.keys(behavior.prototype.methods);
+  methodsKeys.forEach(key => {
+    newMethods[key] = behavior.prototype.methods[key];
+  });
+
+  methodsKeys = Object.keys(methods);
   methodsKeys.forEach(key => {
     newMethods[key] = methods[key];
   });
 
-  const newLifecycle = behavior.prototype.lifecycle;
-  const lifecycleKeys = Object.keys(lifecycle);
+  const newLifecycle = {};
+  let lifecycleKeys = Object.keys(behavior.prototype.lifecycle);
+  lifecycleKeys.forEach(key => {
+    newLifecycle[key] = behavior.prototype.lifecycle[key];
+  });
+
+  lifecycleKeys = Object.keys(lifecycle);
   lifecycleKeys.forEach(key => {
     newLifecycle[key] = lifecycle[key];
   });

--- a/src/extendBehavior.js
+++ b/src/extendBehavior.js
@@ -1,0 +1,29 @@
+import createBehavior from './createBehavior';
+
+/**
+ * Extend an existing a behavior instance
+ * @param {module} behavior - behavior you want to extend
+ * @param {string} name - Name of the extended behavior used for declaration: data-behavior="name"
+ * @param {object} methods - define methods of the behavior
+ * @param {object} lifecycle - Register behavior lifecycle
+ * @returns {Behavior}
+ *
+ * NB: methods or lifestyle fns with the same name will overwrite originals
+ */
+function extendBehavior(behavior, name, methods = {}, lifecycle = {}) {
+  const newMethods = behavior.prototype.methods;
+  const methodsKeys = Object.keys(methods);
+  methodsKeys.forEach(key => {
+    newMethods[key] = methods[key];
+  });
+
+  const newLifecycle = behavior.prototype.lifecycle;
+  const lifecycleKeys = Object.keys(lifecycle);
+  lifecycleKeys.forEach(key => {
+    newLifecycle[key] = lifecycle[key];
+  });
+
+  return createBehavior(name, newMethods, newLifecycle);
+}
+
+export default extendBehavior;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import { default as manageBehaviors } from './manageBehaviors'
 import { default as createBehavior } from './createBehavior'
+import { default as extendBehavior } from './extendBehavior'
 
-export { manageBehaviors, createBehavior }
+export { manageBehaviors, createBehavior, extendBehavior }


### PR DESCRIPTION
Adds the ability to import and extend one behavior, inside of another:

**Example**

Imagine a parent behavior like:

```JavaScript
import { createBehavior } from '@area17/a17-behaviors';

const Parent = createBehavior('Parent',
    {
        logFoo() {
            console.log(this.foo);
        },
    },
    {
        init() {
            this.foo = 'foo';
            this.logFoo();
        },
    }
);

export default Parent;
```

And a child behavior, which extends this parent:

```JavaScript
import { extendBehavior } from '@area17/a17-behaviors';
import Parent from './Parent'

const Child = extendBehavior(Parent, 'Child', {
    logFoo() {
        console.log(`foo = ${ this.foo }`);
    },
});

export default Child;
```

And in your HTML:

```HTML
<div data-behavior="Parent"></div>
<div data-behavior="Child"></div>
```

Then in the browser developer console you would see:

```
foo                                 Parent.js:6
foo = foo                           Child.js:6
```

As the `Child` behavior is an extended version of the `Parent` behavior - where the `logFoo` method has been replaced with a new one. This `Child` behavior `logFoo` has access to all the methods and properties from `Parent` and so is able to see and log out `this.foo`.

Imagine these behaviors with that same HTML:

```JavaScript
import { createBehavior } from '@area17/a17-behaviors';

const Parent = createBehavior('Parent',
    {
        logFoo() {
            this.bar = 'parent-bar';
            console.log(this.foo);
        },
    },
    {
        init() {
            this.foo = 'parent-foo';
            this.logFoo();
        },
    }
);

export default Parent;
```

And a child behavior, which extends this parent:

```JavaScript
import { extendBehavior } from '@area17/a17-behaviors';
import Parent from './Parent'

const Child = extendBehavior(Parent, 'Child', {
    logBar() {
        console.log(this.bar);
    },
    {
        init() {
            this.foo = 'child-foo';
            this.bar = 'child-bar';
            this.returnFoo();
            this.returnBar();
        },
    }
});

export default Child;
```

This time, in the developer console you'll see:

```
parent-foo                             Parent.js:6
child-foo                              Parent.js:6
parent-bar                             Child.js:6
```

As this time the `Child` behavior is `Parent` extended to have a different `init` lifecycle method, a new `logBar` method but it uses the existing `Parent` `logFoo` method and `logFoo` updates `this.bar` within the `Child` behavior.

---

This could be useful if you have a family of behaviors that are related or share methods but have some minor differences between them.